### PR TITLE
Add images to upcoming festivals screen

### DIFF
--- a/src/screens/tabs/festivals.tsx
+++ b/src/screens/tabs/festivals.tsx
@@ -1,16 +1,18 @@
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { View, Text } from "@/theme";
-import { Festival } from "@/api/panchanga/core/festival";
+import Animated from "react-native-reanimated";
+import { Festival, FestivalName } from "@/api/panchanga/core/festival";
 import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
   ColorSchemeName,
   useColorScheme,
+  ImageStyle,
 } from "react-native";
 import { StyleUtils } from "@/theme/style-utils";
 import { getFestivals } from "@/api/panchanga";
-import { getHumanReadableDateWithWeekday, truncateToDay } from "@/util/date";
+import { getHumanReadableDateWithWeekday, truncateToDay, formatMonthYearFromTimestamp } from "@/util/date";
 import { RootStackParamList, TabParamList } from "@/layout/types";
 import { StackScreenProps } from "@react-navigation/stack";
 import { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
@@ -19,6 +21,7 @@ import { useLocation } from "@/context/location";
 import { useGetColor, useThemedStyles } from "@/theme/color";
 import { AppColor } from "@/theme/color";
 import { useTranslation } from "node_modules/react-i18next";
+import { FESTIVAL_IMAGES } from "@/components/festival-images";
 
 const festivalsStylesFactory = (
   theme: ColorSchemeName
@@ -35,13 +38,40 @@ const festivalsStylesFactory = (
   },
   festivalHeader: {
     paddingBottom: "1%",
-    borderBottomWidth: 1,
   },
   festivalContent: {
     ...StyleUtils.flexColumn(5),
-    paddingTop: "2%",
+    paddingVertical: "2%",
+  },
+  festivalRow: {
+    ...StyleUtils.flexRow(12),
+    alignItems: 'center',
+  },
+  festivalInfo: {
+    ...StyleUtils.flexColumn(4),
+    flex: 1,
+  },
+  monthYearSeparator: {
+    ...StyleUtils.flexRow(12),
+    alignItems: 'center',
+    paddingTop: "4%",
+    paddingBottom: "3%",
+  },
+  monthYearLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: useGetColor(AppColor.border, theme),
+  },
+  monthGroup: {
+    ...StyleUtils.flexColumn(6),
   },
 });
+
+const festivalImageStyle: ImageStyle = {
+  width: 56,
+  height: 56,
+  borderRadius: 8,
+};
 
 type FestivalsProps = CompositeScreenProps<
   BottomTabScreenProps<TabParamList, "festivals">,
@@ -55,7 +85,6 @@ type FestivalItemProps = {
 
 function FestivalItem({ festival, onPress }: FestivalItemProps) {
   const festivalsStyles = useThemedStyles(festivalsStylesFactory);
-  const theme = useColorScheme();
   const { i18n, t } = useTranslation();
 
   return (
@@ -64,19 +93,20 @@ function FestivalItem({ festival, onPress }: FestivalItemProps) {
         onPress={() => onPress(festival)}
         style={festivalsStyles.festivalContent}
       >
-        <View
-          style={[
-            festivalsStyles.festivalHeader,
-            { borderBottomColor: useGetColor(AppColor.border, theme) },
-          ]}
-        >
-          <Text neutral tint semibold>
-            {getHumanReadableDateWithWeekday(i18n.language, festival.date)}
-          </Text>
+        <View style={festivalsStyles.festivalRow}>
+          <Animated.Image
+            style={festivalImageStyle}
+            source={FESTIVAL_IMAGES[festival.name as FestivalName]}
+          />
+          <View style={festivalsStyles.festivalInfo}>
+            <Text large semibold>
+              {t(`festivals.${festival.name}.title`)}
+            </Text>
+            <Text neutral tint semibold>
+              {getHumanReadableDateWithWeekday(i18n.language, festival.date)}
+            </Text>
+          </View>
         </View>
-        <Text large semibold>
-          {t(`festivals.${festival.name}.title`)}
-        </Text>
       </TouchableOpacity>
     </View>
   );
@@ -87,11 +117,21 @@ export function Festivals({ navigation }: FestivalsProps) {
   const insets = useSafeAreaInsets();
   const festivals = getFestivals(location!);
   const festivalsStyles = useThemedStyles(festivalsStylesFactory);
+  const { i18n, t } = useTranslation();
+  
   const onFestivalPress = (festival: Festival) => {
     navigation.navigate("festival_details", { festival });
   };
 
-  const { t } = useTranslation();
+  // Group festivals by month/year
+  const groupedFestivals = festivals.reduce((groups: { [key: string]: Festival[] }, festival) => {
+    const monthYear = formatMonthYearFromTimestamp(i18n.language, festival.date);
+    if (!groups[monthYear]) {
+      groups[monthYear] = [];
+    }
+    groups[monthYear].push(festival);
+    return groups;
+  }, {});
 
   return (
     <View
@@ -105,12 +145,22 @@ export function Festivals({ navigation }: FestivalsProps) {
       </Text>
       <ScrollView showsVerticalScrollIndicator={false}>
         <View style={festivalsStyles.festivalsList}>
-          {festivals.map((festival, index) => (
-            <FestivalItem
-              key={`${festival.name}-${index}`}
-              festival={festival}
-              onPress={onFestivalPress}
-            />
+          {Object.entries(groupedFestivals).map(([monthYear, monthFestivals]) => (
+            <View key={monthYear} style={festivalsStyles.monthGroup}>
+              <View style={festivalsStyles.monthYearSeparator}>
+                <Text large bold>
+                  {monthYear}
+                </Text>
+                <View style={festivalsStyles.monthYearLine} />
+              </View>
+              {monthFestivals.map((festival, index) => (
+                <FestivalItem
+                  key={`${festival.name}-${index}`}
+                  festival={festival}
+                  onPress={onFestivalPress}
+                />
+              ))}
+            </View>
           ))}
         </View>
       </ScrollView>

--- a/src/util/date.ts
+++ b/src/util/date.ts
@@ -173,6 +173,12 @@ export function formatDate(language: string, date: Date): string {
     day: "numeric",
   });
 }
+
+export function formatMonthYearFromTimestamp(language: string, timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleDateString(language, { month: "long", year: "numeric" });
+}
+
 /**
  * Generate an array representing days in a month with proper padding for calendar display
  */


### PR DESCRIPTION
We heard that the upcoming festivals list was hard to navigate, so we made it easier to scan by grouping festivals by month and year, and adding an image next to each one.




